### PR TITLE
fix: 修复配置文件中Resource为不存在时，资源选项选值为空的bug

### DIFF
--- a/Views/UI/TaskQueueView.xaml.cs
+++ b/Views/UI/TaskQueueView.xaml.cs
@@ -280,9 +280,8 @@ public partial class TaskQueueView
     private void InitializeResources()
     {
         Instances.GameSettingsUserControlModel.CurrentResources =
-            MaaInterface.Instance?.Resources.Values.Count == 0
-                ? new ObservableCollection<MaaInterface.MaaCustomResource>(MaaInterface.Instance.Resources.Values.ToList())
-                :
+            MaaInterface.Instance?.Resources.Values.Count > 0
+                ? new ObservableCollection<MaaInterface.MaaCustomResource>(MaaInterface.Instance.Resources.Values.ToList()) :
                 [
                     new MaaInterface.MaaCustomResource
                     {
@@ -290,6 +289,8 @@ public partial class TaskQueueView
                         Path = [MaaProcessor.ResourceBase]
                     }
                 ];
+        if (Instances.GameSettingsUserControlModel.CurrentResources.Count > 0 && Instances.GameSettingsUserControlModel.CurrentResources.All(r => r.Name != Instances.GameSettingsUserControlModel.CurrentResource))
+            Instances.GameSettingsUserControlModel.CurrentResource = Instances.GameSettingsUserControlModel.CurrentResources[0].Name ?? "Default";
     }
 
     private (List<DragItemViewModel> updateList, List<DragItemViewModel> removeList) SynchronizeTaskItems(

--- a/Views/UserControl/Settings/TaskOptionSettingsUserControl.xaml
+++ b/Views/UserControl/Settings/TaskOptionSettingsUserControl.xaml
@@ -41,7 +41,7 @@
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     VerticalScrollBarVisibility="Auto">
-                    <Grid x:Name="AdvancedOptionSetting" />
+                    <Grid x:Name="AdvancedOptionSettings" />
                 </hc:ScrollViewer>
             </TabItem>
         </TabControl>


### PR DESCRIPTION
修复配置文件中Resource为不存在时，资源选项选值为空的bug
新任务的entry和option会覆盖旧任务